### PR TITLE
250119 split route and response

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,10 +1,56 @@
-# Cephylas Telemetrer
+# Cephylas Docker Container Telemetrer
 Simple server load logging system for Linux systems,
 written in Rust.
 
 Cephylas comes from "cephonodes hylas", a kind of moth with clear wings.
 
 ## Memo
+```mermaid
+classDiagram
+    class Usages {
+        time: String
+        stats: Vec(HashMap(String,Usage))
+    }
+    class Usage {
+        cpu: CpuUsage
+        memory: MemoryUsage
+        io: IoUsage
+        net: NetUsage
+    }
+
+    class LogCache
+    note for LogCache "HashMap(String,Usages)"
+
+    class LogCacheUsage {
+        cpu: Vec(CpuUsage)
+        memory: Vec(MemoryUsage)
+        io: Vec(IoUsage)
+        net: Vec(NetUsage)
+    }
+```
+```mermaid
+sequenceDiagram
+    participant docker as (Docker socket)
+    participant stream as TcpStream
+    participant buffer as buffer<br/>String
+    participant container_names as container names<br/>String
+    participant struct as Usages<br/>struct
+    participant map as HashMap&lt;ContainerName,UsageData&gt;
+    participant log as (log file)
+    participant cache as LogCache<br/>a
+    
+    note over docker,cache : log cache initialization
+
+    note over docker,cache : log record in every ticks
+
+    docker -->> stream : /containers<br/>/stats
+    stream -->> buffer : stream.read(&mut buffer)
+    buffer -->> map : container_name
+    buffer -->> map : UsageData
+
+
+```
+
 ```mermaid
 sequenceDiagram
     actor user
@@ -59,7 +105,7 @@ sequenceDiagram
     deactivate worker
 ```
 
-## Log summarization
+## Log summarization plan
 ```mermaid
 sequenceDiagram
     participant app as cephylas<br/>application

--- a/core/src/log_cache.rs
+++ b/core/src/log_cache.rs
@@ -1,27 +1,161 @@
-use super::log;
+
+use std::collections::{ VecDeque, HashMap, };
+use std::sync::{ Arc, RwLock, };
+
+use super::log::option_to_string;
 
 pub const MAX_LOG_LENGTH: usize = 8640;
 
-pub struct LogCache {
-    container: Vec<log::Usages>,
+/// 最大 MAX_LOG_LENGTH 個の要素を記録するVecのwrapper
+pub struct LogVec<T> {
+    v: VecDeque<T>
+}
+impl<T> LogVec<T> 
+    where T: ToString
+{
+    /// MAX_LOG_LENGTHのcapacityを設定した状態で初期化します
+    pub fn new() -> Self {
+        let v = VecDeque::with_capacity(MAX_LOG_LENGTH);
+        LogVec { v }
+    }
+    /// 末尾にデータを追加し、MAX_LOG_LENGTHを超えるならば
+    /// 先頭データを削除します
+    pub fn push(self: &mut Self, d: T) {
+        if self.v.len() >= MAX_LOG_LENGTH {
+            self.v.pop_front();
+        }
+        self.v.push_back(d);
+    }
+    //pub fn data(self: &Self) -> &VecDeque<T> { 
+    //    &self.v
+    //}
+    pub fn to_json(self: &Self) -> String {
+        format!(
+            "[{}]",
+            self.v.iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<String>>()
+                .join(",")
+        )
+    }
 }
 
-impl LogCache {
+pub struct UsageCacheMap<T> {
+    map: HashMap<String, LogVec<T>>
+}
+impl<T> UsageCacheMap<T> 
+    where T: ToString
+{
     pub fn new() -> Self {
-        let mut v: Vec<log::Usages> = Vec::new();
-        v.reserve(MAX_LOG_LENGTH);
-        LogCache { container: v, }
-    }
-    pub fn add_and_rotate(self: &mut Self, d: log::Usages) {
-        if self.container.len() >= MAX_LOG_LENGTH {
-            self.container.rotate_left(1);
-            self.container[MAX_LOG_LENGTH - 1] = d;
-        } else {
-            self.container.push(d);
+        UsageCacheMap {
+            map: HashMap::<String, LogVec<T>>::new()
         }
     }
-    pub fn data(self: &Self) -> &Vec<log::Usages> { 
-        &self.container
+    pub fn insert(
+        &mut self, 
+        container_name: String, 
+        usage: T
+    ) {
+        self.map.entry(container_name)
+            .or_insert(
+                LogVec::<T>::new()
+            ).push(usage);
+    }
+    pub fn container_names(&self) -> Vec<&String> {
+        self.map.keys().collect::<Vec<&String>>()
+    }
+    pub fn get(
+        &self,
+        container_name: &str
+    ) -> Option<&LogVec<T>> {
+        self.map.get(container_name)
     }
 }
 
+pub struct TimedCpuUsage {
+    pub time: String,
+    pub percentage: Option<f32>,
+    //TODO 他のフィールドも
+}
+impl std::fmt::Display for TimedCpuUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f, 
+            "{{\"time\":\"{}\",\"percentage\":{}}}", 
+            self.time, 
+            option_to_string(self.percentage)
+        )
+    }
+}
+pub struct TimedMemoryUsage {
+    pub time: String,
+    pub percentage: Option<f32>,
+    //TODO 他のフィールドも
+}
+impl std::fmt::Display for TimedMemoryUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\"time\":\"{}\",\"percentage\":{}}}",
+            self.time,
+            option_to_string(self.percentage)
+        )
+    }
+}
+#[allow(non_snake_case)]
+pub struct TimedIoUsage {
+    pub time: String,
+    pub readkBps: Option<u32>,
+    pub writekBps: Option<u32>,
+    //TODO 他のフィールドも
+}
+impl std::fmt::Display for TimedIoUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\"time\":\"{}\",\"readkBps\":{},\"writekBps\":{}}}",
+            self.time,
+            option_to_string(self.readkBps),
+            option_to_string(self.writekBps)
+        )
+    }
+}
+#[allow(non_snake_case)]
+pub struct TimedNetUsage {
+    pub time: String,
+    pub recvkBps: Option<u32>,
+    pub sendkBps: Option<u32>,
+}
+impl std::fmt::Display for TimedNetUsage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\"time\":\"{}\",\"recvkBps\":{},\"sendkBps\":{}}}",
+            self.time,
+            option_to_string(self.recvkBps),
+            option_to_string(self.sendkBps),
+        )
+    }
+}
+
+pub struct UsageCache {
+    pub cpu: UsageCacheMap<TimedCpuUsage>,
+    pub memory: UsageCacheMap<TimedMemoryUsage>,
+    pub io: UsageCacheMap<TimedIoUsage>,
+    pub net: UsageCacheMap<TimedNetUsage>,
+}
+impl UsageCache {
+    fn new() -> Self {
+        UsageCache {
+            cpu: UsageCacheMap::<TimedCpuUsage>::new(),
+            memory: UsageCacheMap::<TimedMemoryUsage>::new(),
+            io: UsageCacheMap::<TimedIoUsage>::new(),
+            net: UsageCacheMap::<TimedNetUsage>::new(),
+        }
+    }
+}
+
+pub type SharedUsageCache = Arc<RwLock<UsageCache>>;
+pub fn create_shared_cache() -> SharedUsageCache {
+    Arc::new(RwLock::new(UsageCache::new()))
+}

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -4,15 +4,13 @@ mod log;
 mod server;
 mod log_cache;
 
+use log_cache::create_shared_cache;
+
 const MAX_LOG_LINES: usize = 8640;
 
 fn main() -> Result<(), error::Error> {
 
-    let log_cache = 
-        std::sync::Arc::new(
-        std::sync::RwLock::new(
-            log_cache::LogCache::new()
-        ));
+    let log_cache = create_shared_cache();
 
     log::read_log(&log_cache)?;
 

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -122,7 +122,7 @@ fn route_usage(
         // (404が後で返されるはず)
         if let Some(data) = data {
             let response = format!(
-                "HTTP/1.1 200 OK\r\n\r\n [{}]",
+                "HTTP/1.1 200 OK\r\n\r\n {}",
                 data
             );
             stream.write(response.as_bytes())?;

--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -1,45 +1,183 @@
 
+use std::io::{ Read, Write };
+
 use super::error;
-use super::log;
 use super::log_cache;
 
+struct Request<'a> {
+    method: &'a str,
+    uri: &'a str,
+    http_version: &'a str,
+}
+
+impl<'a> TryFrom<&'a str> for Request<'a> {
+    type Error = error::Error;
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        if let [method, uri, http_version] = 
+            value.lines().next()
+            .map(|l| l.split(' '))
+            .ok_or("cannot find first line of request data")?
+            .collect::<Vec<&str>>()[..]
+        {
+            Ok(Request { method, uri, http_version })
+        } else {
+            Err(
+                error::Error::OtherError(
+                    "invalid format in the first line of reqest"
+                    .to_string()
+                )
+            )
+        }
+    }
+}
+
+fn handle_method_not_allowed(
+    stream: &mut std::net::TcpStream,
+) -> Result<(), error::Error> {
+    let response = "HTTP/1.1 405 MethodNotAllowed\r\n\r\n";
+    stream.write(response.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+fn handle_generic_error(
+    stream: &mut std::net::TcpStream,
+    e: &error::Error,
+) -> Result<(), error::Error> {
+    let response = format!(
+        "HTTP/1.1 500 InternalError\r\n\r\n {}",
+        e.to_string(),
+    );
+    stream.write(response.as_bytes())?;
+    stream.flush()?;
+    Ok(())
+}
+
+fn route_not_found(
+    _url: &str,
+    stream: &mut std::net::TcpStream,
+    _log_cache: &log_cache::SharedUsageCache,
+) -> Result<bool, error::Error> {
+    let response = "HTTP/1.1 404 NotFound\r\n\r\n";
+    stream.write(response.as_bytes())?;
+    stream.flush()?;
+    
+    Ok(true)
+}
+
+fn route_containers(
+    url: &str,
+    stream: &mut std::net::TcpStream,
+    log_cache: &log_cache::SharedUsageCache,
+) -> Result<bool, error::Error> {
+
+    let pattern = "/containers";
+    if url != pattern { return Ok(false) }
+
+    let lock = log_cache.read().map_err(|e| e.to_string())?;
+    let container_names = lock.cpu.container_names();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\n\r\n [{}]",
+        container_names
+            .iter()
+            .map(|s| format!("\"{}\"", s))
+            .collect::<Vec<String>>()
+            .join(",")
+    );
+    stream.write(response.as_bytes())?;
+    stream.flush()?;
+
+    Ok(true)
+}
+
+fn route_usage(
+    url: &str,
+    stream: &mut std::net::TcpStream,
+    log_cache: &log_cache::SharedUsageCache,
+) -> Result<bool, error::Error> {
+    let parts: Vec<&str> = url.split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
+    if let ["containers", container_name, resource] = &parts[..] {
+        let lock = log_cache.read().map_err(|e| e.to_string())?;
+
+        let data = match *resource {
+            "cpu" => lock.cpu
+                .get(container_name)
+                .map(|v| v.to_json()),
+            "memory" => lock.memory
+                .get(container_name)
+                .map(|v| v.to_json()),
+            "io" => lock.io
+                .get(container_name)
+                .map(|v| v.to_json()),
+            "net" => lock.net
+                .get(container_name)
+                .map(|v| v.to_json()),
+            _ => None,
+        };
+
+        // コンテナ名が存在すればデータを返し、
+        // 無ければルート自体にマッチしなかったことにする
+        // リソース名がマッチしなかった場合もそうする
+        // (404が後で返されるはず)
+        if let Some(data) = data {
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\r\n [{}]",
+                data
+            );
+            stream.write(response.as_bytes())?;
+            stream.flush()?;
+            return Ok(true);
+        } else {
+            return Ok(false)
+        }
+    } else {
+        // url pattern is not matched
+        return Ok(false);
+    }
+}
+
 fn handle_connection(
-    mut stream: std::net::TcpStream,
-    log_cache: 
-        &std::sync::Arc<
-            std::sync::RwLock<
-                log_cache::LogCache
-            >
-        >
+    stream: &mut std::net::TcpStream,
+    log_cache: &log_cache::SharedUsageCache,
 ) -> Result<(), error::Error> {
     let mut buffer = [0; 1024];
-    std::io::Read::read(&mut stream, &mut buffer)?;
+    stream.read(&mut buffer)?;
 
-    println!("Request: {}", String::from_utf8_lossy(&buffer[..]));
+    let request_data = String::from_utf8_lossy(&buffer[..]);
+    println!("Request: {}", request_data);
 
-    let response = format!(
-        "HTTP/1.1 200 OK\r\n\r\n {}", 
-        log::custom_dump(&log::reshape_log_cache(log_cache)?)
-    );
-    std::io::Write::write(&mut stream, response.as_bytes())?;
-    std::io::Write::flush(&mut stream)?;
+    let request = Request::try_from(request_data.as_ref())?;
+    if request.method != "GET" {
+        handle_method_not_allowed(stream)?;
+        return Ok(());
+    }
+
+    let routes = [
+        route_containers,
+        route_usage,
+        route_not_found,
+    ];
+
+    for route in routes {
+        match route(request.uri, stream, log_cache) {
+            Ok(true) => { /* uri match, handled */ break; },
+            Ok(false) => { /* do nothing */ },
+            Err(e) => { handle_generic_error(stream, &e)?; }
+        }
+    }
 
     Ok(())
 }
 
 pub fn start_server(
-    log_cache:
-        &std::sync::Arc<
-            std::sync::RwLock<
-                log_cache::LogCache
-            >
-        >
+    log_cache: &log_cache::SharedUsageCache
 ) -> Result<(), error::Error> {
     let listener = std::net::TcpListener::bind("0.0.0.0:7878")?;
 
     for stream in listener.incoming() {
-        let stream = stream?;
-        handle_connection(stream, log_cache)?;
+        let mut stream = stream?;
+        handle_connection(&mut stream, log_cache)?;
     }
 
     Ok(())

--- a/next/src/app/page.tsx
+++ b/next/src/app/page.tsx
@@ -16,27 +16,38 @@ export default async function Home() {
     return (<div>コンテナ名取得中...</div>);
   }
   const containerNames = await containersResponse.json();
-  console.timeEnd("データ取得");
-
-
-  console.time("データ成型");
 
   const datasetsCpu: { 
     label: string;
     data: any[];
   }[] = [];
   for (const containerName of containerNames) {
-    const cpuResponse = 
+    const response = 
       await fetch(`http://cephylas:7878/containers/${containerName}/cpu`);
-    if (!cpuResponse.ok) return (<div>CPU使用率取得中...</div>);
-    const rawData = await cpuResponse.json();
-    console.log("rawData: ", rawData);
+    if (!response.ok) return (<div>CPU使用率取得中...</div>);
+    const rawData = await response.json();
+    //console.log("rawData: ", rawData);
     datasetsCpu.push({
       label: containerName,
       data: rawData.map((d: any) => ({ x: new Date(d.time), y: d.percentage }))
     });
   }
-  console.log('%o', datasetsCpu);
+  const datasetsMemory: { 
+    label: string;
+    data: any[];
+  }[] = [];
+  for (const containerName of containerNames) {
+    const response = 
+      await fetch(`http://cephylas:7878/containers/${containerName}/memory`);
+    if (!response.ok) return (<div>Memory使用率取得中...</div>);
+    const rawData = await response.json();
+    //console.log("rawData: ", rawData);
+    datasetsMemory.push({
+      label: containerName,
+      data: rawData.map((d: any) => ({ x: new Date(d.time), y: d.percentage }))
+    });
+  }
+  //console.log('%o', datasetsCpu);
   
   //const datasetsCpu = prepareDatasets(
   //  logs, d => ({ x: d.time, y: d.cpu.percentage })
@@ -46,9 +57,7 @@ export default async function Home() {
   //);
   //const datasetsDisk = prepareDatasetsIOandNet(logs, 'io');
   //const datasetsNet = prepareDatasetsIOandNet(logs, 'net');
-
-  console.timeEnd("データ成型");
-
+  console.timeEnd("データ取得");
 
   return (
     <>
@@ -59,12 +68,12 @@ export default async function Home() {
           datasets={datasetsCpu} 
           title='CPU usage (%)' 
         />
-        {/*
         <Chart 
           chartId='chartjs-memory-usage'
           datasets={datasetsMemory} 
           title='Memory usage (%)'
         />
+        {/*
         <Chart
           chartId='chartjs-disk-usage'
           datasets={datasetsDisk} 


### PR DESCRIPTION
巨大なJSONのハンドリングを避けることでメモリ使用量を1/10以下に削減。
- リソース使用量のキャッシュを種類ごとに分割
- Rust側の簡易HTTPサーバにルータ機能を持たせて返却するJSONを細分化