### PR TITLE
LTTBダウンサンプルコードのミスを修正

### DIFF
--- a/core/src/server.rs
+++ b/core/src/server.rs
@@ -246,7 +246,7 @@ fn handle_connection(
     stream.read(&mut buffer)?;
 
     let request_data = String::from_utf8_lossy(&buffer[..]);
-    println!("Request: {}", request_data);
+    //println!("Request: {}", request_data);
 
     let request = Request::try_from(request_data.as_ref())?;
     if request.method != "GET" {


### PR DESCRIPTION
last_pointが更新されず、常に前回のチャンクの最後の点になっていた
本来は前回のチャンクの代表点を指定しなければならないので修正